### PR TITLE
Gutter changes part 2

### DIFF
--- a/src/main/generated/resources/assets/minestuck/lang/en_us.json
+++ b/src/main/generated/resources/assets/minestuck/lang/en_us.json
@@ -551,6 +551,8 @@
   "commands.minestuck.debuglands.must_enter": "You must have entered before you can create debug lands",
   "commands.minestuck.grist.add": "Successfully modified the grist cache for %s players.",
   "commands.minestuck.grist.add.failure": "Failed to modify the grist cache for %s.",
+  "commands.minestuck.grist.add.no_capacity": "Failed to add to the grist cache for %s due to lacking capacity.",
+  "commands.minestuck.grist.add.partial": "Partially added grist to the grist cache for %s, but failed to add %s.",
   "commands.minestuck.grist.add.success": "Successfully modified the grist cache for %s.",
   "commands.minestuck.grist.get": "%s has: %s",
   "commands.minestuck.grist.set": "Set the grist cache for %s players to %s.",

--- a/src/main/java/com/mraof/minestuck/alchemy/GristGutter.java
+++ b/src/main/java/com/mraof/minestuck/alchemy/GristGutter.java
@@ -163,7 +163,7 @@ public class GristGutter
 		
 		NonNegativeGristSet capacity = GristHelper.getCapacitySet(data);
 		GristSet gristToTransfer = this.takeWithinCapacity(spliceAmount, capacity);
-		GristSet remainder = GristHelper.increaseAndReturnExcess(data, gristToTransfer);
+		GristSet remainder = data.getGristCache().addWithinCapacity(gristToTransfer);
 		if(!remainder.isEmpty())
 			throw new IllegalStateException("Took more grist than could be given to the player. Got back grist: " + remainder);
 	}

--- a/src/main/java/com/mraof/minestuck/alchemy/GristGutter.java
+++ b/src/main/java/com/mraof/minestuck/alchemy/GristGutter.java
@@ -138,7 +138,7 @@ public class GristGutter
 	public static void onServerTickEvent(TickEvent.ServerTickEvent event)
 	{
 		//noinspection resource
-		if(event.getServer().overworld().getGameTime() % 200 == 0)
+		if(event.phase == TickEvent.Phase.START && event.getServer().overworld().getGameTime() % 200 == 0)
 		{
 			for(Session session : SessionHandler.get(event.getServer()).getSessions())
 			{

--- a/src/main/java/com/mraof/minestuck/alchemy/GristGutter.java
+++ b/src/main/java/com/mraof/minestuck/alchemy/GristGutter.java
@@ -163,7 +163,7 @@ public class GristGutter
 		
 		NonNegativeGristSet capacity = data.getGristCache().getCapacitySet();
 		GristSet gristToTransfer = this.takeWithinCapacity(spliceAmount, capacity);
-		GristSet remainder = data.getGristCache().addWithinCapacity(gristToTransfer);
+		GristSet remainder = data.getGristCache().addWithinCapacity(gristToTransfer, null);
 		if(!remainder.isEmpty())
 			throw new IllegalStateException("Took more grist than could be given to the player. Got back grist: " + remainder);
 	}

--- a/src/main/java/com/mraof/minestuck/alchemy/GristGutter.java
+++ b/src/main/java/com/mraof/minestuck/alchemy/GristGutter.java
@@ -161,7 +161,7 @@ public class GristGutter
 		
 		long spliceAmount = (long) (data.getEcheladder().getGristCapacity() * getDistributionRateModifier());
 		
-		NonNegativeGristSet capacity = GristHelper.getCapacitySet(data);
+		NonNegativeGristSet capacity = data.getGristCache().getCapacitySet();
 		GristSet gristToTransfer = this.takeWithinCapacity(spliceAmount, capacity);
 		GristSet remainder = data.getGristCache().addWithinCapacity(gristToTransfer);
 		if(!remainder.isEmpty())

--- a/src/main/java/com/mraof/minestuck/alchemy/GristGutter.java
+++ b/src/main/java/com/mraof/minestuck/alchemy/GristGutter.java
@@ -8,12 +8,13 @@ import com.mraof.minestuck.skaianet.Session;
 import com.mraof.minestuck.skaianet.SessionHandler;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.RandomSource;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.server.ServerLifecycleHooks;
 
-import java.util.Set;
+import java.util.*;
 
 /**
  * A class that handles Grist overflow whenever you acquire too much grist.
@@ -148,21 +149,24 @@ public class GristGutter
 	
 	private void distributeToPlayers(Set<PlayerIdentifier> players, MinecraftServer server)
 	{
-		// TODO iterate in a random order, so that no player gets priority
-		for(PlayerIdentifier player : players)
+		RandomSource rand = server.overworld().random;
+		List<PlayerIdentifier> playerList = new ArrayList<>(players);
+		Collections.shuffle(playerList, new Random(rand.nextLong()));
+		
+		for(PlayerIdentifier player : playerList)
 		{
-			tickDistributionToPlayer(player, server);
+			tickDistributionToPlayer(player, server, rand);
 		}
 	}
 	
-	private void tickDistributionToPlayer(PlayerIdentifier player, MinecraftServer server)
+	private void tickDistributionToPlayer(PlayerIdentifier player, MinecraftServer server, RandomSource rand)
 	{
 		PlayerData data = PlayerSavedData.getData(player, server);
 		
 		long spliceAmount = (long) (data.getEcheladder().getGristCapacity() * getDistributionRateModifier());
 		
 		NonNegativeGristSet capacity = data.getGristCache().getCapacitySet();
-		GristSet gristToTransfer = this.takeWithinCapacity(spliceAmount, capacity);
+		GristSet gristToTransfer = this.takeWithinCapacity(spliceAmount, capacity, rand);
 		GristSet remainder = data.getGristCache().addWithinCapacity(gristToTransfer, null);
 		if(!remainder.isEmpty())
 			throw new IllegalStateException("Took more grist than could be given to the player. Got back grist: " + remainder);
@@ -173,12 +177,14 @@ public class GristGutter
 		return 1D/20D;
 	}
 	
-	private GristSet takeWithinCapacity(long amount, NonNegativeGristSet capacity)
+	private GristSet takeWithinCapacity(long amount, NonNegativeGristSet capacity, RandomSource rand)
 	{
 		long remaining = amount;
 		GristSet takenGrist = new GristSet();
-		//TODO randomize iteration order
-		for(GristAmount capacityAmount : capacity.getAmounts())
+		List<GristAmount> amounts = new ArrayList<>(capacity.getAmounts());
+		Collections.shuffle(amounts, new Random(rand.nextLong()));
+		
+		for(GristAmount capacityAmount : amounts)
 		{
 			GristType type = capacityAmount.getType();
 			long amountInGutter = this.gristSet.getGrist(type);

--- a/src/main/java/com/mraof/minestuck/alchemy/GristHelper.java
+++ b/src/main/java/com/mraof/minestuck/alchemy/GristHelper.java
@@ -1,17 +1,9 @@
 package com.mraof.minestuck.alchemy;
 
-import com.mraof.minestuck.MinestuckConfig;
-import com.mraof.minestuck.computer.editmode.EditData;
-import com.mraof.minestuck.computer.editmode.ServerEditHandler;
 import com.mraof.minestuck.entity.underling.UnderlingEntity;
 import com.mraof.minestuck.event.GristDropsEvent;
-import com.mraof.minestuck.network.GristToastPacket;
-import com.mraof.minestuck.network.MSPacketHandler;
 import com.mraof.minestuck.player.PlayerIdentifier;
 import com.mraof.minestuck.player.PlayerSavedData;
-import com.mraof.minestuck.skaianet.SburbConnection;
-import com.mraof.minestuck.skaianet.SkaianetHandler;
-import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.RandomSource;
 import net.minecraft.util.random.WeightedEntry;
 import net.minecraft.util.random.WeightedRandom;
@@ -116,57 +108,4 @@ public class GristHelper
 		return false;
 	}
 	
-	/**
-	 * Uses the encoded version of the username!
-	 */
-	public static void decrease(Level level, PlayerIdentifier player, GristSet set)
-	{
-		PlayerSavedData.getData(player, level).getGristCache().addWithGutter(set.copy().scale(-1));
-	}
-	
-	public static void decreaseAndNotify(Level level, PlayerIdentifier player, GristSet set, GristHelper.EnumSource source)
-	{
-		decrease(level, player, set);
-		notify(level.getServer(), player, set.copy().scale(-1), source);
-	}
-	
-	public static void increaseAndNotify(Level level, PlayerIdentifier player, GristSet set, GristHelper.EnumSource source)
-	{
-		PlayerSavedData.getData(player, level).getGristCache().addWithGutter(set);
-		notify(level.getServer(), player, set, source);
-	}
-	
-	/**
-	 * Sends a request to make a client-side Toast Notification for incoming/outgoing grist, if enabled in the config.
-	 *
-	 * @param server Used for getting the ServerPlayer from their PlayerIdentifier
-	 * @param player The Player that the notification should appear for.
-	 * @param set    The grist type and value pairs associated with the notifications. There can be multiple pairs in the set, but usually only one.
-	 * @param source Indicates where the notification is coming from. See EnumSource.
-	 */
-	public static void notify(MinecraftServer server, PlayerIdentifier player, GristSet set, EnumSource source)
-	{
-		if(MinestuckConfig.SERVER.showGristChanges.get())
-		{
-			long cacheLimit = PlayerSavedData.getData(player, server).getEcheladder().getGristCapacity();
-			
-			if(player.getPlayer(server) != null)
-				MSPacketHandler.sendToPlayer(new GristToastPacket(set, source, cacheLimit, true), player.getPlayer(server));
-			
-			if (source == EnumSource.SERVER)
-			{
-				SburbConnection sc = SkaianetHandler.get(server).getActiveConnection(player);
-				if(sc == null)
-					return;
-				
-				EditData ed = ServerEditHandler.getData(server, sc);
-				if(ed == null)
-					return;
-				
-				if(!player.appliesTo(ed.getEditor()))
-					MSPacketHandler.sendToPlayer(new GristToastPacket(set, source, cacheLimit, false), ed.getEditor());
-
-			}
-		}
-	}
 }

--- a/src/main/java/com/mraof/minestuck/alchemy/GristHelper.java
+++ b/src/main/java/com/mraof/minestuck/alchemy/GristHelper.java
@@ -127,31 +127,31 @@ public class GristHelper
 	public static void decreaseAndNotify(Level level, PlayerIdentifier player, GristSet set, GristHelper.EnumSource source)
 	{
 		decrease(level, player, set);
-		notify(level.getServer(), player, set, source, false);
+		notify(level.getServer(), player, set.copy().scale(-1), source);
 	}
 	
 	public static void increaseAndNotify(Level level, PlayerIdentifier player, GristSet set, GristHelper.EnumSource source)
 	{
 		PlayerSavedData.getData(player, level).getGristCache().addWithGutter(set);
-		notify(level.getServer(), player, set, source, true);
+		notify(level.getServer(), player, set, source);
 	}
 	
 	/**
 	 * Sends a request to make a client-side Toast Notification for incoming/outgoing grist, if enabled in the config.
+	 *
 	 * @param server Used for getting the ServerPlayer from their PlayerIdentifier
 	 * @param player The Player that the notification should appear for.
-	 * @param set The grist type and value pairs associated with the notifications. There can be multiple pairs in the set, but usually only one.
+	 * @param set    The grist type and value pairs associated with the notifications. There can be multiple pairs in the set, but usually only one.
 	 * @param source Indicates where the notification is coming from. See EnumSource.
-	 * @param increase Indicates whether the grist is gained or lost.
 	 */
-	public static void notify(MinecraftServer server, PlayerIdentifier player, GristSet set, GristHelper.EnumSource source, boolean increase)
+	public static void notify(MinecraftServer server, PlayerIdentifier player, GristSet set, EnumSource source)
 	{
 		if(MinestuckConfig.SERVER.showGristChanges.get())
 		{
 			long cacheLimit = PlayerSavedData.getData(player, server).getEcheladder().getGristCapacity();
 			
 			if(player.getPlayer(server) != null)
-				MSPacketHandler.sendToPlayer(new GristToastPacket(set, source, increase, cacheLimit, true), player.getPlayer(server));
+				MSPacketHandler.sendToPlayer(new GristToastPacket(set, source, cacheLimit, true), player.getPlayer(server));
 			
 			if (source == EnumSource.SERVER)
 			{
@@ -164,7 +164,7 @@ public class GristHelper
 					return;
 				
 				if(!player.appliesTo(ed.getEditor()))
-					MSPacketHandler.sendToPlayer(new GristToastPacket(set, source, increase, cacheLimit, false), ed.getEditor());
+					MSPacketHandler.sendToPlayer(new GristToastPacket(set, source, cacheLimit, false), ed.getEditor());
 
 			}
 		}

--- a/src/main/java/com/mraof/minestuck/alchemy/GristHelper.java
+++ b/src/main/java/com/mraof/minestuck/alchemy/GristHelper.java
@@ -90,7 +90,7 @@ public class GristHelper
 	 */
 	public static long getGrist(Level level, PlayerIdentifier player, GristType type)
 	{
-		return PlayerSavedData.getData(player, level).getGristCache().getGrist(type);
+		return PlayerSavedData.getData(player, level).getGristCache().getGristSet().getGrist(type);
 	}
 	
 	public static long getGrist(Level level, PlayerIdentifier player, Supplier<GristType> type)
@@ -100,12 +100,12 @@ public class GristHelper
 	
 	public static boolean canAfford(ServerPlayer player, GristSet cost)
 	{
-		return canAfford(PlayerSavedData.getData(player).getGristCache(), cost);
+		return canAfford(PlayerSavedData.getData(player).getGristCache().getGristSet(), cost);
 	}
 	
 	public static boolean canAfford(Level level, PlayerIdentifier player, GristSet cost)
 	{
-		return canAfford(PlayerSavedData.getData(player, level).getGristCache(), cost);
+		return canAfford(PlayerSavedData.getData(player, level).getGristCache().getGristSet(), cost);
 	}
 	
 	public static boolean canAfford(GristSet base, GristSet cost)
@@ -169,11 +169,11 @@ public class GristHelper
 		Objects.requireNonNull(data);
 		Objects.requireNonNull(set);
 		
-		NonNegativeGristSet newCache = new NonNegativeGristSet(data.getGristCache());
+		NonNegativeGristSet newCache = new NonNegativeGristSet(data.getGristCache().getGristSet());
 		
 		GristSet excessGrist = newCache.addWithinCapacity(set, data.getEcheladder().getGristCapacity());
 		
-		data.setGristCache(newCache);
+		data.getGristCache().setGristSet(newCache);
 		return excessGrist;
 	}
 	
@@ -183,8 +183,8 @@ public class GristHelper
 		NonNegativeGristSet capacitySet = new NonNegativeGristSet();
 		for(GristType type : GristTypes.values())
 		{
-			if(data.getGristCache().getGrist(type) < capacity)
-				capacitySet.addGrist(type, capacity - data.getGristCache().getGrist(type));
+			if(data.getGristCache().getGristSet().getGrist(type) < capacity)
+				capacitySet.addGrist(type, capacity - data.getGristCache().getGristSet().getGrist(type));
 		}
 		return capacitySet;
 	}

--- a/src/main/java/com/mraof/minestuck/alchemy/GristHelper.java
+++ b/src/main/java/com/mraof/minestuck/alchemy/GristHelper.java
@@ -7,13 +7,11 @@ import com.mraof.minestuck.entity.underling.UnderlingEntity;
 import com.mraof.minestuck.event.GristDropsEvent;
 import com.mraof.minestuck.network.GristToastPacket;
 import com.mraof.minestuck.network.MSPacketHandler;
-import com.mraof.minestuck.player.PlayerData;
 import com.mraof.minestuck.player.PlayerIdentifier;
 import com.mraof.minestuck.player.PlayerSavedData;
 import com.mraof.minestuck.skaianet.SburbConnection;
 import com.mraof.minestuck.skaianet.SkaianetHandler;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.RandomSource;
 import net.minecraft.util.random.WeightedEntry;
 import net.minecraft.util.random.WeightedRandom;
@@ -96,16 +94,6 @@ public class GristHelper
 		return getGrist(level, player, type.get());
 	}
 	
-	public static boolean canAfford(ServerPlayer player, GristSet cost)
-	{
-		return canAfford(PlayerSavedData.getData(player).getGristCache().getGristSet(), cost);
-	}
-	
-	public static boolean canAfford(Level level, PlayerIdentifier player, GristSet cost)
-	{
-		return canAfford(PlayerSavedData.getData(player, level).getGristCache().getGristSet(), cost);
-	}
-	
 	public static boolean canAfford(GristSet base, GristSet cost)
 	{
 		if(base == null || cost == null)
@@ -140,18 +128,6 @@ public class GristHelper
 	{
 		decrease(level, player, set);
 		notify(level.getServer(), player, set, source, false);
-	}
-	
-	public static NonNegativeGristSet getCapacitySet(PlayerData data)
-	{
-		long capacity = data.getEcheladder().getGristCapacity();
-		NonNegativeGristSet capacitySet = new NonNegativeGristSet();
-		for(GristType type : GristTypes.values())
-		{
-			if(data.getGristCache().getGristSet().getGrist(type) < capacity)
-				capacitySet.addGrist(type, capacity - data.getGristCache().getGristSet().getGrist(type));
-		}
-		return capacitySet;
 	}
 	
 	public static void increaseAndNotify(Level level, PlayerIdentifier player, GristSet set, GristHelper.EnumSource source)

--- a/src/main/java/com/mraof/minestuck/alchemy/GristHelper.java
+++ b/src/main/java/com/mraof/minestuck/alchemy/GristHelper.java
@@ -2,8 +2,8 @@ package com.mraof.minestuck.alchemy;
 
 import com.mraof.minestuck.entity.underling.UnderlingEntity;
 import com.mraof.minestuck.event.GristDropsEvent;
+import com.mraof.minestuck.player.GristCache;
 import com.mraof.minestuck.player.PlayerIdentifier;
-import com.mraof.minestuck.player.PlayerSavedData;
 import net.minecraft.util.RandomSource;
 import net.minecraft.util.random.WeightedEntry;
 import net.minecraft.util.random.WeightedRandom;
@@ -78,7 +78,7 @@ public class GristHelper
 	 */
 	public static long getGrist(Level level, PlayerIdentifier player, GristType type)
 	{
-		return PlayerSavedData.getData(player, level).getGristCache().getGristSet().getGrist(type);
+		return GristCache.get(level, player).getGristSet().getGrist(type);
 	}
 	
 	public static long getGrist(Level level, PlayerIdentifier player, Supplier<GristType> type)

--- a/src/main/java/com/mraof/minestuck/alchemy/GristHelper.java
+++ b/src/main/java/com/mraof/minestuck/alchemy/GristHelper.java
@@ -2,18 +2,15 @@ package com.mraof.minestuck.alchemy;
 
 import com.mraof.minestuck.entity.underling.UnderlingEntity;
 import com.mraof.minestuck.event.GristDropsEvent;
-import com.mraof.minestuck.player.GristCache;
 import com.mraof.minestuck.player.PlayerIdentifier;
 import net.minecraft.util.RandomSource;
 import net.minecraft.util.random.WeightedEntry;
 import net.minecraft.util.random.WeightedRandom;
-import net.minecraft.world.level.Level;
 import net.minecraftforge.common.MinecraftForge;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.function.Supplier;
 
 public class GristHelper
 {
@@ -73,19 +70,7 @@ public class GristHelper
 		
 	}
 	
-	/**
-	 * A shortened statement to obtain a certain grist count.
-	 */
-	public static long getGrist(Level level, PlayerIdentifier player, GristType type)
-	{
-		return GristCache.get(level, player).getGristSet().getGrist(type);
-	}
-	
-	public static long getGrist(Level level, PlayerIdentifier player, Supplier<GristType> type)
-	{
-		return getGrist(level, player, type.get());
-	}
-	
+	//TODO figure out how best to check cache capacity client-side
 	public static boolean canAfford(GristSet base, GristSet cost)
 	{
 		if(base == null || cost == null)

--- a/src/main/java/com/mraof/minestuck/alchemy/GristHelper.java
+++ b/src/main/java/com/mraof/minestuck/alchemy/GristHelper.java
@@ -171,9 +171,7 @@ public class GristHelper
 		
 		NonNegativeGristSet newCache = new NonNegativeGristSet(data.getGristCache());
 		
-		newCache.addGrist(set);
-		long capacity = data.getEcheladder().getGristCapacity();
-		GristSet excessGrist = newCache.removeOverCapacity(capacity);
+		GristSet excessGrist = newCache.addWithinCapacity(set, data.getEcheladder().getGristCapacity());
 		
 		data.setGristCache(newCache);
 		return excessGrist;

--- a/src/main/java/com/mraof/minestuck/alchemy/GristSet.java
+++ b/src/main/java/com/mraof/minestuck/alchemy/GristSet.java
@@ -241,7 +241,15 @@ public class GristSet
 	{
 		return this.gristTypes.values().stream().allMatch(amount -> amount == 0);
 	}
-
+	
+	public boolean equalContent(GristSet other)
+	{
+		for(GristType type : GristTypes.values())
+			if(this.getGrist(type) != other.getGrist(type))
+				return false;
+		return true;
+	}
+	
 	@Override
 	public String toString()
 	{

--- a/src/main/java/com/mraof/minestuck/alchemy/GristSet.java
+++ b/src/main/java/com/mraof/minestuck/alchemy/GristSet.java
@@ -10,13 +10,15 @@ import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.GsonHelper;
-import net.minecraft.util.Mth;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -194,42 +196,6 @@ public class GristSet
 		}
 		return this;
 
-	}
-	
-	/**
-	 * Adds or removes grist such that the grist does not exceed the given capacity or falls below 0.
-	 * This function should be able to handle a grist type already being out of bounds, for which it would behave as if it was right at the bound.
-	 * Returns any excess grist.
-	 */
-	public GristSet addWithinCapacity(GristSet grist, long capacity)
-	{
-		if(capacity < 0)
-			throw new IllegalArgumentException("Capacity under 0 not allowed.");
-		
-		GristSet remainder = new GristSet();
-		
-		for(GristAmount amount : grist.getAmounts())
-		{
-			if(amount.getAmount() > 0)
-			{
-				long toAdd = Mth.clamp(capacity - this.getGrist(amount.getType()), 0, amount.getAmount());
-				long remainingAmount = amount.getAmount() - toAdd;
-				if(toAdd != 0)
-					this.addGrist(amount.getType(), toAdd);
-				if(remainingAmount != 0)
-					remainder.addGrist(amount.getType(), remainingAmount);
-			} else if(amount.getAmount() < 0)
-			{
-				long toAdd = Mth.clamp(-this.getGrist(amount.getType()), amount.getAmount(), 0);
-				long remainingAmount = amount.getAmount() - toAdd;
-				if(toAdd != 0)
-					this.addGrist(amount.getType(), toAdd);
-				if(remainingAmount != 0)
-					remainder.addGrist(amount.getType(), remainingAmount);
-			}
-		}
-		
-		return remainder;
 	}
 	
 	/**

--- a/src/main/java/com/mraof/minestuck/blockentity/machine/AlchemiterBlockEntity.java
+++ b/src/main/java/com/mraof/minestuck/blockentity/machine/AlchemiterBlockEntity.java
@@ -7,11 +7,11 @@ import com.mraof.minestuck.block.MSBlocks;
 import com.mraof.minestuck.block.machine.AlchemiterBlock;
 import com.mraof.minestuck.blockentity.MSBlockEntityTypes;
 import com.mraof.minestuck.client.gui.MSScreenFactories;
-import com.mraof.minestuck.client.gui.toasts.GristToast;
 import com.mraof.minestuck.event.AlchemyEvent;
 import com.mraof.minestuck.player.IdentifierHandler;
 import com.mraof.minestuck.player.PlayerIdentifier;
 import com.mraof.minestuck.blockentity.IColored;
+import com.mraof.minestuck.player.PlayerSavedData;
 import com.mraof.minestuck.util.ColorHandler;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -267,7 +267,7 @@ public class AlchemiterBlockEntity extends BlockEntity implements IColored, Gris
 		//get the grist cost
 		GristSet cost = getGristCost(quantity);
 		
-		boolean canAfford = GristHelper.canAfford(player, cost);
+		boolean canAfford = PlayerSavedData.getData(player).getGristCache().canAfford(cost);
 		
 		if(canAfford)
 		{

--- a/src/main/java/com/mraof/minestuck/blockentity/machine/AlchemiterBlockEntity.java
+++ b/src/main/java/com/mraof/minestuck/blockentity/machine/AlchemiterBlockEntity.java
@@ -266,10 +266,8 @@ public class AlchemiterBlockEntity extends BlockEntity implements IColored, Gris
 		//get the grist cost
 		GristSet cost = getGristCost(quantity);
 		
-		if(GristCache.get(player).canAfford(cost))
+		if(GristCache.get(player).tryTake(cost, GristHelper.EnumSource.CLIENT))
 		{
-			GristCache.get(player).takeWithGutter(cost, GristHelper.EnumSource.CLIENT);
-			
 			AlchemyEvent event = new AlchemyEvent(IdentifierHandler.encode(player), this, getDowel(), newItem, cost);
 			MinecraftForge.EVENT_BUS.post(event);
 			newItem = event.getItemResult();

--- a/src/main/java/com/mraof/minestuck/blockentity/machine/AlchemiterBlockEntity.java
+++ b/src/main/java/com/mraof/minestuck/blockentity/machine/AlchemiterBlockEntity.java
@@ -8,10 +8,9 @@ import com.mraof.minestuck.block.machine.AlchemiterBlock;
 import com.mraof.minestuck.blockentity.MSBlockEntityTypes;
 import com.mraof.minestuck.client.gui.MSScreenFactories;
 import com.mraof.minestuck.event.AlchemyEvent;
+import com.mraof.minestuck.player.GristCache;
 import com.mraof.minestuck.player.IdentifierHandler;
-import com.mraof.minestuck.player.PlayerIdentifier;
 import com.mraof.minestuck.blockentity.IColored;
-import com.mraof.minestuck.player.PlayerSavedData;
 import com.mraof.minestuck.util.ColorHandler;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -267,16 +266,11 @@ public class AlchemiterBlockEntity extends BlockEntity implements IColored, Gris
 		//get the grist cost
 		GristSet cost = getGristCost(quantity);
 		
-		boolean canAfford = PlayerSavedData.getData(player).getGristCache().canAfford(cost);
-		
-		if(canAfford)
+		if(GristCache.get(player).canAfford(cost))
 		{
+			GristCache.get(player).takeWithGutter(cost, GristHelper.EnumSource.CLIENT);
 			
-			
-			PlayerIdentifier pid = IdentifierHandler.encode(player);
-			PlayerSavedData.getData(pid, level).getGristCache().takeWithGutter(cost, GristHelper.EnumSource.CLIENT);
-			
-			AlchemyEvent event = new AlchemyEvent(pid, this, getDowel(), newItem, cost);
+			AlchemyEvent event = new AlchemyEvent(IdentifierHandler.encode(player), this, getDowel(), newItem, cost);
 			MinecraftForge.EVENT_BUS.post(event);
 			newItem = event.getItemResult();
 			

--- a/src/main/java/com/mraof/minestuck/blockentity/machine/AlchemiterBlockEntity.java
+++ b/src/main/java/com/mraof/minestuck/blockentity/machine/AlchemiterBlockEntity.java
@@ -274,7 +274,7 @@ public class AlchemiterBlockEntity extends BlockEntity implements IColored, Gris
 			
 			
 			PlayerIdentifier pid = IdentifierHandler.encode(player);
-			GristHelper.decreaseAndNotify(level, pid, cost, GristHelper.EnumSource.CLIENT);
+			PlayerSavedData.getData(pid, level).getGristCache().takeWithGutter(cost, GristHelper.EnumSource.CLIENT);
 			
 			AlchemyEvent event = new AlchemyEvent(pid, this, getDowel(), newItem, cost);
 			MinecraftForge.EVENT_BUS.post(event);

--- a/src/main/java/com/mraof/minestuck/blockentity/machine/MiniAlchemiterBlockEntity.java
+++ b/src/main/java/com/mraof/minestuck/blockentity/machine/MiniAlchemiterBlockEntity.java
@@ -105,7 +105,7 @@ public class MiniAlchemiterBlockEntity extends MachineProcessBlockEntity impleme
 		
 		GristSet cost = GristCostRecipe.findCostForItem(newItem, wildcardGrist, false, level);
 		
-		GristHelper.decreaseAndNotify(level, owner, cost, GristHelper.EnumSource.CLIENT);
+		PlayerSavedData.getData(owner, level).getGristCache().takeWithGutter(cost, GristHelper.EnumSource.CLIENT);
 		
 		AlchemyEvent event = new AlchemyEvent(owner, this, itemHandler.getStackInSlot(INPUT), newItem, cost);
 		MinecraftForge.EVENT_BUS.post(event);

--- a/src/main/java/com/mraof/minestuck/blockentity/machine/MiniAlchemiterBlockEntity.java
+++ b/src/main/java/com/mraof/minestuck/blockentity/machine/MiniAlchemiterBlockEntity.java
@@ -7,6 +7,7 @@ import com.mraof.minestuck.event.AlchemyEvent;
 import com.mraof.minestuck.inventory.MiniAlchemiterMenu;
 import com.mraof.minestuck.player.IdentifierHandler;
 import com.mraof.minestuck.player.PlayerIdentifier;
+import com.mraof.minestuck.player.PlayerSavedData;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
@@ -87,7 +88,7 @@ public class MiniAlchemiterBlockEntity extends MachineProcessBlockEntity impleme
 			}
 			GristSet cost = GristCostRecipe.findCostForItem(newItem, wildcardGrist, false, level);
 			
-			return GristHelper.canAfford(level, owner, cost);
+			return PlayerSavedData.getData(owner, level).getGristCache().canAfford(cost);
 		}
 		else
 		{
@@ -211,7 +212,7 @@ public class MiniAlchemiterBlockEntity extends MachineProcessBlockEntity impleme
 					}
 					// We need to make a copy to preserve the original grist amounts and avoid scaling values that have already been scaled. Keeps scaling linear as opposed to exponential.
 					scale_cost = cost.copy().scale(lvl);
-					if (!GristHelper.canAfford(level, owner, scale_cost))
+					if (!PlayerSavedData.getData(owner, level).getGristCache().canAfford(scale_cost))
 					{
 						return lvl - 1;
 					}

--- a/src/main/java/com/mraof/minestuck/blockentity/machine/MiniAlchemiterBlockEntity.java
+++ b/src/main/java/com/mraof/minestuck/blockentity/machine/MiniAlchemiterBlockEntity.java
@@ -5,9 +5,9 @@ import com.mraof.minestuck.block.MSBlocks;
 import com.mraof.minestuck.blockentity.MSBlockEntityTypes;
 import com.mraof.minestuck.event.AlchemyEvent;
 import com.mraof.minestuck.inventory.MiniAlchemiterMenu;
+import com.mraof.minestuck.player.GristCache;
 import com.mraof.minestuck.player.IdentifierHandler;
 import com.mraof.minestuck.player.PlayerIdentifier;
-import com.mraof.minestuck.player.PlayerSavedData;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
@@ -88,7 +88,7 @@ public class MiniAlchemiterBlockEntity extends MachineProcessBlockEntity impleme
 			}
 			GristSet cost = GristCostRecipe.findCostForItem(newItem, wildcardGrist, false, level);
 			
-			return PlayerSavedData.getData(owner, level).getGristCache().canAfford(cost);
+			return GristCache.get(level, owner).canAfford(cost);
 		}
 		else
 		{
@@ -105,7 +105,7 @@ public class MiniAlchemiterBlockEntity extends MachineProcessBlockEntity impleme
 		
 		GristSet cost = GristCostRecipe.findCostForItem(newItem, wildcardGrist, false, level);
 		
-		PlayerSavedData.getData(owner, level).getGristCache().takeWithGutter(cost, GristHelper.EnumSource.CLIENT);
+		GristCache.get(level, owner).takeWithGutter(cost, GristHelper.EnumSource.CLIENT);
 		
 		AlchemyEvent event = new AlchemyEvent(owner, this, itemHandler.getStackInSlot(INPUT), newItem, cost);
 		MinecraftForge.EVENT_BUS.post(event);
@@ -212,7 +212,7 @@ public class MiniAlchemiterBlockEntity extends MachineProcessBlockEntity impleme
 					}
 					// We need to make a copy to preserve the original grist amounts and avoid scaling values that have already been scaled. Keeps scaling linear as opposed to exponential.
 					scale_cost = cost.copy().scale(lvl);
-					if (!PlayerSavedData.getData(owner, level).getGristCache().canAfford(scale_cost))
+					if (!GristCache.get(level, owner).canAfford(scale_cost))
 					{
 						return lvl - 1;
 					}

--- a/src/main/java/com/mraof/minestuck/blockentity/machine/MiniAlchemiterBlockEntity.java
+++ b/src/main/java/com/mraof/minestuck/blockentity/machine/MiniAlchemiterBlockEntity.java
@@ -105,7 +105,7 @@ public class MiniAlchemiterBlockEntity extends MachineProcessBlockEntity impleme
 		
 		GristSet cost = GristCostRecipe.findCostForItem(newItem, wildcardGrist, false, level);
 		
-		GristHelper.decrease(level, owner, cost);
+		GristHelper.decreaseAndNotify(level, owner, cost, GristHelper.EnumSource.CLIENT);
 		
 		AlchemyEvent event = new AlchemyEvent(owner, this, itemHandler.getStackInSlot(INPUT), newItem, cost);
 		MinecraftForge.EVENT_BUS.post(event);

--- a/src/main/java/com/mraof/minestuck/client/gui/toasts/GristToast.java
+++ b/src/main/java/com/mraof/minestuck/client/gui/toasts/GristToast.java
@@ -7,6 +7,7 @@ import com.mraof.minestuck.alchemy.GristHelper;
 import com.mraof.minestuck.alchemy.GristSet;
 import com.mraof.minestuck.alchemy.GristType;
 import com.mraof.minestuck.client.util.GuiUtil;
+import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiComponent;
@@ -16,6 +17,7 @@ import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Mth;
 
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.List;
 
 /**
@@ -23,6 +25,8 @@ import java.util.List;
  * Utilizes vanilla Minecraft's Toasts system, which is what the advancement and recipe popups use.
  * @author Caldw3ll
  */
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
 public class GristToast implements Toast
 {
 	private static final ResourceLocation TEXTURE = new ResourceLocation("minestuck", "textures/gui/toasts.png");
@@ -42,12 +46,12 @@ public class GristToast implements Toast
 	private static final float SCALE_X = 0.6F;
 	private static final float SCALE_Y = 0.6F;
 	
-	private GristType type;
+	private final GristType type;
 	private long difference;
 	private long cacheLimit;
 	private long gristCache;
-	private GristHelper.EnumSource source;
-	private boolean increase;
+	private final GristHelper.EnumSource source;
+	private final boolean increase;
 	
 	private long lastChanged;
 	private boolean changed;
@@ -170,9 +174,6 @@ public class GristToast implements Toast
 	//modified version of drawIcon() from MinestuckScreen.java
 	private void drawIcon(int x, int y, ResourceLocation icon)
 	{
-		if(icon == null || Minecraft.getInstance() == null)
-			return;
-		
 		RenderSystem.setShader(GameRenderer::getPositionTexShader);
 		RenderSystem.setShaderTexture(0, icon);
 		
@@ -218,7 +219,7 @@ public class GristToast implements Toast
 			gristToast.addGrist(pDifference, pCacheLimit);
 	}
 	
-	public static void sendGristMessage(GristSet set, GristHelper.EnumSource source, boolean increase, long cacheLimit, GristSet gristCache)
+	public static void sendGristMessage(GristSet set, GristHelper.EnumSource source, long cacheLimit, GristSet gristCache)
 	{
 		
 		List<GristAmount> reqs = set.getAmounts();
@@ -239,9 +240,9 @@ public class GristToast implements Toast
 			
 			//ALWAYS use addOrUpdate(), and not addToast, or else grist toasts won't leave a running tally of the amount.
 			if (difference >= 0)
-				GristToast.addOrUpdate(Minecraft.getInstance().getToasts(), type, difference, source, increase, cacheLimit, total);
+				GristToast.addOrUpdate(Minecraft.getInstance().getToasts(), type, difference, source, true, cacheLimit, total);
 			else
-				GristToast.addOrUpdate(Minecraft.getInstance().getToasts(), type, Math.abs(difference), source, !(increase), cacheLimit, total);
+				GristToast.addOrUpdate(Minecraft.getInstance().getToasts(), type, Math.abs(difference), source, false, cacheLimit, total);
 		}
 	}
 	

--- a/src/main/java/com/mraof/minestuck/command/GristCommand.java
+++ b/src/main/java/com/mraof/minestuck/command/GristCommand.java
@@ -7,6 +7,7 @@ import com.mraof.minestuck.alchemy.GristSet;
 import com.mraof.minestuck.alchemy.NonNegativeGristSet;
 import com.mraof.minestuck.command.argument.GristSetArgument;
 import com.mraof.minestuck.player.IdentifierHandler;
+import com.mraof.minestuck.player.PlayerIdentifier;
 import com.mraof.minestuck.player.PlayerSavedData;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
@@ -59,7 +60,9 @@ public class GristCommand
 		{
 			try
 			{
-				GristHelper.increaseAndNotify(player.level, IdentifierHandler.encode(player), grist, GristHelper.EnumSource.CONSOLE);
+				PlayerIdentifier player1 = IdentifierHandler.encode(player);
+				PlayerSavedData.getData(player1, player.level).getGristCache()
+						.addWithGutter(grist, GristHelper.EnumSource.CONSOLE);
 				i++;
 				source.sendSuccess(Component.translatable(SUCCESS, player.getDisplayName()), true);
 			} catch(IllegalArgumentException e)

--- a/src/main/java/com/mraof/minestuck/command/GristCommand.java
+++ b/src/main/java/com/mraof/minestuck/command/GristCommand.java
@@ -2,11 +2,10 @@ package com.mraof.minestuck.command;
 
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.builder.ArgumentBuilder;
-import com.mraof.minestuck.client.gui.toasts.GristToast;
-import com.mraof.minestuck.command.argument.GristSetArgument;
 import com.mraof.minestuck.alchemy.GristHelper;
 import com.mraof.minestuck.alchemy.GristSet;
 import com.mraof.minestuck.alchemy.NonNegativeGristSet;
+import com.mraof.minestuck.command.argument.GristSetArgument;
 import com.mraof.minestuck.player.IdentifierHandler;
 import com.mraof.minestuck.player.PlayerSavedData;
 import net.minecraft.commands.CommandSourceStack;
@@ -47,7 +46,7 @@ public class GristCommand
 	{
 		for(ServerPlayer player : players)
 		{
-			GristSet grist = PlayerSavedData.getData(player).getGristCache();
+			GristSet grist = PlayerSavedData.getData(player).getGristCache().getGristSet();
 			source.sendSuccess(Component.translatable(GET, player.getDisplayName(), grist.asTextComponent()), false);
 		}
 		return players.size();
@@ -77,7 +76,7 @@ public class GristCommand
 	{
 		for(ServerPlayer player : players)
 		{
-			PlayerSavedData.getData(player).setGristCache(grist);
+			PlayerSavedData.getData(player).getGristCache().setGristSet(grist);
 		}
 		source.sendSuccess(Component.translatable(SET, players.size(), grist.asTextComponent()), true);
 		return players.size();

--- a/src/main/java/com/mraof/minestuck/command/GristCommand.java
+++ b/src/main/java/com/mraof/minestuck/command/GristCommand.java
@@ -76,7 +76,7 @@ public class GristCommand
 	{
 		for(ServerPlayer player : players)
 		{
-			PlayerSavedData.getData(player).getGristCache().setGristSet(grist);
+			PlayerSavedData.getData(player).getGristCache().set(grist);
 		}
 		source.sendSuccess(Component.translatable(SET, players.size(), grist.asTextComponent()), true);
 		return players.size();

--- a/src/main/java/com/mraof/minestuck/command/GristCommand.java
+++ b/src/main/java/com/mraof/minestuck/command/GristCommand.java
@@ -58,8 +58,9 @@ public class GristCommand
 		{
 			try
 			{
-				GristCache.get(player).addWithGutter(grist, GristHelper.EnumSource.CONSOLE);
+				GristSet remainingGrist = GristCache.get(player).addWithinCapacity(grist, GristHelper.EnumSource.CONSOLE);
 				i++;
+				//TODO change message to take into account the grist that didn't fit in the cache
 				source.sendSuccess(Component.translatable(SUCCESS, player.getDisplayName()), true);
 			} catch(IllegalArgumentException e)
 			{

--- a/src/main/java/com/mraof/minestuck/command/GristCommand.java
+++ b/src/main/java/com/mraof/minestuck/command/GristCommand.java
@@ -6,9 +6,7 @@ import com.mraof.minestuck.alchemy.GristHelper;
 import com.mraof.minestuck.alchemy.GristSet;
 import com.mraof.minestuck.alchemy.NonNegativeGristSet;
 import com.mraof.minestuck.command.argument.GristSetArgument;
-import com.mraof.minestuck.player.IdentifierHandler;
-import com.mraof.minestuck.player.PlayerIdentifier;
-import com.mraof.minestuck.player.PlayerSavedData;
+import com.mraof.minestuck.player.GristCache;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.commands.arguments.EntityArgument;
@@ -47,7 +45,7 @@ public class GristCommand
 	{
 		for(ServerPlayer player : players)
 		{
-			GristSet grist = PlayerSavedData.getData(player).getGristCache().getGristSet();
+			GristSet grist = GristCache.get(player).getGristSet();
 			source.sendSuccess(Component.translatable(GET, player.getDisplayName(), grist.asTextComponent()), false);
 		}
 		return players.size();
@@ -60,9 +58,7 @@ public class GristCommand
 		{
 			try
 			{
-				PlayerIdentifier player1 = IdentifierHandler.encode(player);
-				PlayerSavedData.getData(player1, player.level).getGristCache()
-						.addWithGutter(grist, GristHelper.EnumSource.CONSOLE);
+				GristCache.get(player).addWithGutter(grist, GristHelper.EnumSource.CONSOLE);
 				i++;
 				source.sendSuccess(Component.translatable(SUCCESS, player.getDisplayName()), true);
 			} catch(IllegalArgumentException e)
@@ -79,7 +75,7 @@ public class GristCommand
 	{
 		for(ServerPlayer player : players)
 		{
-			PlayerSavedData.getData(player).getGristCache().set(grist);
+			GristCache.get(player).set(grist);
 		}
 		source.sendSuccess(Component.translatable(SET, players.size(), grist.asTextComponent()), true);
 		return players.size();

--- a/src/main/java/com/mraof/minestuck/command/GristCommand.java
+++ b/src/main/java/com/mraof/minestuck/command/GristCommand.java
@@ -20,6 +20,8 @@ public class GristCommand
 	public static final String GET = "commands.minestuck.grist.get";
 	public static final String ADD = "commands.minestuck.grist.add";
 	public static final String SUCCESS = "commands.minestuck.grist.add.success";
+	public static final String PARTIAL_SUCCESS = "commands.minestuck.grist.add.partial";
+	public static final String NO_CAPACITY = "commands.minestuck.grist.add.no_capacity";
 	public static final String FAILURE = "commands.minestuck.grist.add.failure";
 	public static final String SET = "commands.minestuck.grist.set";
 	
@@ -59,16 +61,25 @@ public class GristCommand
 			try
 			{
 				GristSet remainingGrist = GristCache.get(player).addWithinCapacity(grist, GristHelper.EnumSource.CONSOLE);
-				i++;
-				//TODO change message to take into account the grist that didn't fit in the cache
-				source.sendSuccess(Component.translatable(SUCCESS, player.getDisplayName()), true);
+				if(remainingGrist.equalContent(grist))
+				{
+					source.sendFailure(Component.translatable(NO_CAPACITY, player.getDisplayName()));
+				} else
+				{
+					i++;
+					if(remainingGrist.isEmpty())
+						source.sendSuccess(Component.translatable(SUCCESS, player.getDisplayName()), true);
+					else
+						source.sendSuccess(Component.translatable(PARTIAL_SUCCESS, player.getDisplayName(), remainingGrist.asTextComponent()), true);
+				}
 			} catch(IllegalArgumentException e)
 			{
 				e.printStackTrace();
 				source.sendFailure(Component.translatable(FAILURE, player.getDisplayName()));
 			}
 		}
-		source.sendSuccess(Component.translatable(ADD, i), true);
+		if(players.size() > 1)
+			source.sendSuccess(Component.translatable(ADD, i), true);
 		return i;
 	}
 	

--- a/src/main/java/com/mraof/minestuck/command/GutterCommand.java
+++ b/src/main/java/com/mraof/minestuck/command/GutterCommand.java
@@ -16,6 +16,8 @@ import net.minecraft.server.level.ServerPlayer;
 import static net.minecraft.commands.Commands.LEVEL_GAMEMASTERS;
 import static net.minecraft.commands.Commands.literal;
 
+//TODO add/remove/clear subcommands
+//TODO how about a player argument to be able to pick which session to target
 public class GutterCommand
 {
 	public static final SimpleCommandExceptionType NO_SESSION_EXCEPTION = new SimpleCommandExceptionType(Component.literal("Cannot find gutter because you are not in a session."));

--- a/src/main/java/com/mraof/minestuck/command/SendGristCommand.java
+++ b/src/main/java/com/mraof/minestuck/command/SendGristCommand.java
@@ -3,12 +3,12 @@ package com.mraof.minestuck.command;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
-import com.mraof.minestuck.command.argument.GristSetArgument;
 import com.mraof.minestuck.alchemy.GristHelper;
 import com.mraof.minestuck.alchemy.NonNegativeGristSet;
+import com.mraof.minestuck.command.argument.GristSetArgument;
+import com.mraof.minestuck.player.GristCache;
 import com.mraof.minestuck.player.IdentifierHandler;
 import com.mraof.minestuck.player.PlayerIdentifier;
-import com.mraof.minestuck.player.PlayerSavedData;
 import com.mraof.minestuck.skaianet.SburbConnection;
 import com.mraof.minestuck.skaianet.SessionHandler;
 import com.mraof.minestuck.skaianet.SkaianetHandler;
@@ -40,13 +40,10 @@ public class SendGristCommand
 		ServerPlayer player = source.getPlayerOrException();
 		if(isPermittedFor(player, target))
 		{
-			if(PlayerSavedData.getData(player).getGristCache().canAfford(grist))
+			if(GristCache.get(player).canAfford(grist))
 			{
-				PlayerIdentifier player2 = IdentifierHandler.encode(player);
-				PlayerSavedData.getData(player2, player.level).getGristCache().takeWithGutter(grist, GristHelper.EnumSource.SENDGRIST);
-				PlayerIdentifier player1 = IdentifierHandler.encode(target);
-				PlayerSavedData.getData(player1, player.level).getGristCache()
-						.addWithGutter(grist, GristHelper.EnumSource.SENDGRIST);
+				GristCache.get(player).takeWithGutter(grist, GristHelper.EnumSource.SENDGRIST);
+				GristCache.get(target).addWithGutter(grist, GristHelper.EnumSource.SENDGRIST);
 				source.sendSuccess(Component.translatable(SUCCESS, target.getDisplayName(), grist.asTextComponent()), true);
 				target.sendSystemMessage(Component.translatable(RECEIVE, player.getDisplayName(), grist.asTextComponent()));
 				return 1;

--- a/src/main/java/com/mraof/minestuck/command/SendGristCommand.java
+++ b/src/main/java/com/mraof/minestuck/command/SendGristCommand.java
@@ -42,8 +42,11 @@ public class SendGristCommand
 		{
 			if(PlayerSavedData.getData(player).getGristCache().canAfford(grist))
 			{
-				GristHelper.decreaseAndNotify(player.level, IdentifierHandler.encode(player), grist, GristHelper.EnumSource.SENDGRIST);
-				GristHelper.increaseAndNotify(player.level, IdentifierHandler.encode(target), grist, GristHelper.EnumSource.SENDGRIST);
+				PlayerIdentifier player2 = IdentifierHandler.encode(player);
+				PlayerSavedData.getData(player2, player.level).getGristCache().takeWithGutter(grist, GristHelper.EnumSource.SENDGRIST);
+				PlayerIdentifier player1 = IdentifierHandler.encode(target);
+				PlayerSavedData.getData(player1, player.level).getGristCache()
+						.addWithGutter(grist, GristHelper.EnumSource.SENDGRIST);
 				source.sendSuccess(Component.translatable(SUCCESS, target.getDisplayName(), grist.asTextComponent()), true);
 				target.sendSystemMessage(Component.translatable(RECEIVE, player.getDisplayName(), grist.asTextComponent()));
 				return 1;

--- a/src/main/java/com/mraof/minestuck/command/SendGristCommand.java
+++ b/src/main/java/com/mraof/minestuck/command/SendGristCommand.java
@@ -40,9 +40,8 @@ public class SendGristCommand
 		ServerPlayer player = source.getPlayerOrException();
 		if(isPermittedFor(player, target))
 		{
-			if(GristCache.get(player).canAfford(grist))
+			if(GristCache.get(player).tryTake(grist, GristHelper.EnumSource.SENDGRIST))
 			{
-				GristCache.get(player).takeWithGutter(grist, GristHelper.EnumSource.SENDGRIST);
 				GristCache.get(target).addWithGutter(grist, GristHelper.EnumSource.SENDGRIST);
 				source.sendSuccess(Component.translatable(SUCCESS, target.getDisplayName(), grist.asTextComponent()), true);
 				target.sendSystemMessage(Component.translatable(RECEIVE, player.getDisplayName(), grist.asTextComponent()));

--- a/src/main/java/com/mraof/minestuck/command/SendGristCommand.java
+++ b/src/main/java/com/mraof/minestuck/command/SendGristCommand.java
@@ -8,6 +8,7 @@ import com.mraof.minestuck.alchemy.GristHelper;
 import com.mraof.minestuck.alchemy.NonNegativeGristSet;
 import com.mraof.minestuck.player.IdentifierHandler;
 import com.mraof.minestuck.player.PlayerIdentifier;
+import com.mraof.minestuck.player.PlayerSavedData;
 import com.mraof.minestuck.skaianet.SburbConnection;
 import com.mraof.minestuck.skaianet.SessionHandler;
 import com.mraof.minestuck.skaianet.SkaianetHandler;
@@ -39,7 +40,7 @@ public class SendGristCommand
 		ServerPlayer player = source.getPlayerOrException();
 		if(isPermittedFor(player, target))
 		{
-			if(GristHelper.canAfford(player, grist))
+			if(PlayerSavedData.getData(player).getGristCache().canAfford(grist))
 			{
 				GristHelper.decreaseAndNotify(player.level, IdentifierHandler.encode(player), grist, GristHelper.EnumSource.SENDGRIST);
 				GristHelper.increaseAndNotify(player.level, IdentifierHandler.encode(target), grist, GristHelper.EnumSource.SENDGRIST);

--- a/src/main/java/com/mraof/minestuck/computer/editmode/EditData.java
+++ b/src/main/java/com/mraof/minestuck/computer/editmode/EditData.java
@@ -1,15 +1,14 @@
 package com.mraof.minestuck.computer.editmode;
 
 import com.mraof.minestuck.entity.DecoyEntity;
-import com.mraof.minestuck.alchemy.GristSet;
 import com.mraof.minestuck.network.MSPacketHandler;
 import com.mraof.minestuck.network.ServerEditPacket;
 import com.mraof.minestuck.network.data.GristCachePacket;
+import com.mraof.minestuck.player.GristCache;
 import com.mraof.minestuck.player.IdentifierHandler;
 import com.mraof.minestuck.player.PlayerIdentifier;
 import com.mraof.minestuck.skaianet.SburbConnection;
 import com.mraof.minestuck.util.Teleport;
-import com.mraof.minestuck.player.PlayerSavedData;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.NbtOps;
@@ -54,6 +53,11 @@ public class EditData
 		return connection;
 	}
 	
+	public GristCache getGristCache()
+	{
+		return GristCache.get(player.server, connection.getClientIdentifier());
+	}
+	
 	/**
 	 * @return the player that activated and is in editmode (not necessarily the server player of the connection)
 	 */
@@ -72,10 +76,8 @@ public class EditData
 	
 	public void sendGristCacheToEditor()
 	{
-		GristSet cache = PlayerSavedData.getData(connection.getClientIdentifier(), getEditor().server).getGristCache().getGristSet();
-		ServerPlayer editor = getEditor();
-		GristCachePacket packet = new GristCachePacket(cache, true);
-		MSPacketHandler.sendToPlayer(packet, editor);
+		GristCachePacket packet = new GristCachePacket(this.getGristCache().getGristSet(), true);
+		MSPacketHandler.sendToPlayer(packet, this.getEditor());
 	}
 	
 	public void sendGivenItemsToEditor()

--- a/src/main/java/com/mraof/minestuck/computer/editmode/EditData.java
+++ b/src/main/java/com/mraof/minestuck/computer/editmode/EditData.java
@@ -72,7 +72,7 @@ public class EditData
 	
 	public void sendGristCacheToEditor()
 	{
-		GristSet cache = PlayerSavedData.getData(connection.getClientIdentifier(), getEditor().server).getGristCache();
+		GristSet cache = PlayerSavedData.getData(connection.getClientIdentifier(), getEditor().server).getGristCache().getGristSet();
 		ServerPlayer editor = getEditor();
 		GristCachePacket packet = new GristCachePacket(cache, true);
 		MSPacketHandler.sendToPlayer(packet, editor);

--- a/src/main/java/com/mraof/minestuck/computer/editmode/ServerEditHandler.java
+++ b/src/main/java/com/mraof/minestuck/computer/editmode/ServerEditHandler.java
@@ -11,6 +11,8 @@ import com.mraof.minestuck.event.ConnectionClosedEvent;
 import com.mraof.minestuck.event.SburbEvent;
 import com.mraof.minestuck.network.MSPacketHandler;
 import com.mraof.minestuck.network.ServerEditPacket;
+import com.mraof.minestuck.player.GristCache;
+import com.mraof.minestuck.player.PlayerData;
 import com.mraof.minestuck.player.PlayerIdentifier;
 import com.mraof.minestuck.player.PlayerSavedData;
 import com.mraof.minestuck.skaianet.SburbConnection;
@@ -324,7 +326,7 @@ public final class ServerEditHandler	//TODO Consider splitting this class into t
 			if(entry != null && !isBlockItem(stack.getItem()))
 			{
 				GristSet cost = entry.getCurrentCost(data.connection);
-				if(GristHelper.canAfford(PlayerSavedData.getData(data.connection.getClientIdentifier(), event.getPlayer().level).getGristCache().getGristSet(), cost))
+				if(PlayerSavedData.getData(data.connection.getClientIdentifier(), event.getPlayer().level).getGristCache().canAfford(cost))
 				{
 					GristHelper.decreaseAndNotify(event.getPlayer().level, data.connection.getClientIdentifier(), cost, GristHelper.EnumSource.SERVER);
 					
@@ -377,17 +379,19 @@ public final class ServerEditHandler	//TODO Consider splitting this class into t
 			cleanStackNBT(stack, data.connection, event.getLevel());
 			
 			DeployEntry entry = DeployList.getEntryForItem(stack, data.connection, event.getEntity().level);
+			GristCache gristCache = PlayerSavedData.getData(data.connection.getClientIdentifier(), event.getLevel()).getGristCache();
 			if(entry != null)
 			{
 				GristSet cost = entry.getCurrentCost(data.connection);
-				if(!GristHelper.canAfford(event.getLevel(), data.connection.getClientIdentifier(), cost))
+				if(!gristCache.canAfford(cost))
 				{
 					if(cost != null)
 						event.getEntity().sendSystemMessage(cost.createMissingMessage());
 					event.setCanceled(true);
 				}
 			}
-			else if(!isBlockItem(stack.getItem()) || !GristHelper.canAfford(event.getLevel(), data.connection.getClientIdentifier(), GristCostRecipe.findCostForItem(stack, null, false, event.getLevel())))
+			else if(!isBlockItem(stack.getItem()) ||
+					!gristCache.canAfford(GristCostRecipe.findCostForItem(stack, null, false, event.getLevel())))
 			{
 				event.setCanceled(true);
 			}

--- a/src/main/java/com/mraof/minestuck/computer/editmode/ServerEditHandler.java
+++ b/src/main/java/com/mraof/minestuck/computer/editmode/ServerEditHandler.java
@@ -2,24 +2,23 @@ package com.mraof.minestuck.computer.editmode;
 
 import com.mraof.minestuck.Minestuck;
 import com.mraof.minestuck.MinestuckConfig;
-import com.mraof.minestuck.client.gui.toasts.GristToast;
-import com.mraof.minestuck.entity.DecoyEntity;
-import com.mraof.minestuck.event.ConnectionClosedEvent;
-import com.mraof.minestuck.event.SburbEvent;
 import com.mraof.minestuck.alchemy.GristCostRecipe;
 import com.mraof.minestuck.alchemy.GristHelper;
 import com.mraof.minestuck.alchemy.GristSet;
 import com.mraof.minestuck.alchemy.GristTypes;
+import com.mraof.minestuck.entity.DecoyEntity;
+import com.mraof.minestuck.event.ConnectionClosedEvent;
+import com.mraof.minestuck.event.SburbEvent;
 import com.mraof.minestuck.network.MSPacketHandler;
 import com.mraof.minestuck.network.ServerEditPacket;
 import com.mraof.minestuck.player.PlayerIdentifier;
+import com.mraof.minestuck.player.PlayerSavedData;
 import com.mraof.minestuck.skaianet.SburbConnection;
 import com.mraof.minestuck.skaianet.SburbHandler;
 import com.mraof.minestuck.skaianet.SkaianetHandler;
 import com.mraof.minestuck.util.Teleport;
 import com.mraof.minestuck.world.MSDimensions;
 import com.mraof.minestuck.world.storage.MSExtraData;
-import com.mraof.minestuck.player.PlayerSavedData;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.GlobalPos;
@@ -325,7 +324,7 @@ public final class ServerEditHandler	//TODO Consider splitting this class into t
 			if(entry != null && !isBlockItem(stack.getItem()))
 			{
 				GristSet cost = entry.getCurrentCost(data.connection);
-				if(GristHelper.canAfford(PlayerSavedData.getData(data.connection.getClientIdentifier(), event.getPlayer().level).getGristCache(), cost))
+				if(GristHelper.canAfford(PlayerSavedData.getData(data.connection.getClientIdentifier(), event.getPlayer().level).getGristCache().getGristSet(), cost))
 				{
 					GristHelper.decreaseAndNotify(event.getPlayer().level, data.connection.getClientIdentifier(), cost, GristHelper.EnumSource.SERVER);
 					

--- a/src/main/java/com/mraof/minestuck/computer/editmode/ServerEditHandler.java
+++ b/src/main/java/com/mraof/minestuck/computer/editmode/ServerEditHandler.java
@@ -13,7 +13,6 @@ import com.mraof.minestuck.network.MSPacketHandler;
 import com.mraof.minestuck.network.ServerEditPacket;
 import com.mraof.minestuck.player.GristCache;
 import com.mraof.minestuck.player.PlayerIdentifier;
-import com.mraof.minestuck.player.PlayerSavedData;
 import com.mraof.minestuck.skaianet.SburbConnection;
 import com.mraof.minestuck.skaianet.SburbHandler;
 import com.mraof.minestuck.skaianet.SkaianetHandler;
@@ -325,9 +324,9 @@ public final class ServerEditHandler	//TODO Consider splitting this class into t
 			if(entry != null && !isBlockItem(stack.getItem()))
 			{
 				GristSet cost = entry.getCurrentCost(data.connection);
-				if(PlayerSavedData.getData(data.connection.getClientIdentifier(), event.getPlayer().level).getGristCache().canAfford(cost))
+				if(data.getGristCache().canAfford(cost))
 				{
-					PlayerSavedData.getData(data.connection.getClientIdentifier(), event.getPlayer().level).getGristCache().takeWithGutter(cost, GristHelper.EnumSource.SERVER);
+					data.getGristCache().takeWithGutter(cost, GristHelper.EnumSource.SERVER);
 					
 					data.connection.setHasGivenItem(entry);
 					if(!data.connection.isMain())
@@ -378,7 +377,7 @@ public final class ServerEditHandler	//TODO Consider splitting this class into t
 			cleanStackNBT(stack, data.connection, event.getLevel());
 			
 			DeployEntry entry = DeployList.getEntryForItem(stack, data.connection, event.getEntity().level);
-			GristCache gristCache = PlayerSavedData.getData(data.connection.getClientIdentifier(), event.getLevel()).getGristCache();
+			GristCache gristCache = data.getGristCache();
 			if(entry != null)
 			{
 				GristSet cost = entry.getCurrentCost(data.connection);
@@ -429,9 +428,7 @@ public final class ServerEditHandler	//TODO Consider splitting this class into t
 			EditData data = getData(event.getEntity());
 			if(!MinestuckConfig.SERVER.gristRefund.get())
 			{
-				Level level = event.getLevel();
-				GristSet set = new GristSet(GristTypes.BUILD,1);
-				PlayerSavedData.getData(data.connection.getClientIdentifier(), level).getGristCache().takeWithGutter(set, GristHelper.EnumSource.SERVER);
+				data.getGristCache().takeWithGutter(new GristSet(GristTypes.BUILD,1), GristHelper.EnumSource.SERVER);
 			}
 			else
 			{
@@ -440,9 +437,7 @@ public final class ServerEditHandler	//TODO Consider splitting this class into t
 				GristSet set = GristCostRecipe.findCostForItem(stack, null, false, event.getLevel());
 				if(set != null && !set.isEmpty())
 				{
-					Level level = event.getLevel();
-					PlayerSavedData.getData(data.connection.getClientIdentifier(), level).getGristCache()
-							.addWithGutter(set, GristHelper.EnumSource.SERVER);
+					data.getGristCache().addWithGutter(set, GristHelper.EnumSource.SERVER);
 				}
 			}
 		}
@@ -473,13 +468,13 @@ public final class ServerEditHandler	//TODO Consider splitting this class into t
 						SburbHandler.giveItems(player.server, c.getClientIdentifier());
 					if(!cost.isEmpty())
 					{
-						PlayerSavedData.getData(c.getClientIdentifier(), player.level).getGristCache().takeWithGutter(cost, GristHelper.EnumSource.SERVER);
+						data.getGristCache().takeWithGutter(cost, GristHelper.EnumSource.SERVER);
 					}
 					player.getInventory().items.set(player.getInventory().selected, ItemStack.EMPTY);
 				} else
 				{
 					GristSet set = GristCostRecipe.findCostForItem(stack, null, false, player.getCommandSenderWorld());
-					PlayerSavedData.getData(c.getClientIdentifier(), player.level).getGristCache().takeWithGutter(set, GristHelper.EnumSource.SERVER);
+					data.getGristCache().takeWithGutter(set, GristHelper.EnumSource.SERVER);
 				}
 			}
 		}

--- a/src/main/java/com/mraof/minestuck/data/MinestuckEnUsLanguageProvider.java
+++ b/src/main/java/com/mraof/minestuck/data/MinestuckEnUsLanguageProvider.java
@@ -1738,6 +1738,8 @@ public class MinestuckEnUsLanguageProvider extends MinestuckLanguageProvider
 		add(GristCommand.GET, "%s has: %s");
 		add(GristCommand.ADD, "Successfully modified the grist cache for %s players.");
 		add(GristCommand.SUCCESS, "Successfully modified the grist cache for %s.");
+		add(GristCommand.PARTIAL_SUCCESS, "Partially added grist to the grist cache for %s, but failed to add %s.");
+		add(GristCommand.NO_CAPACITY, "Failed to add to the grist cache for %s due to lacking capacity.");
 		add(GristCommand.FAILURE, "Failed to modify the grist cache for %s.");
 		add(GristCommand.SET, "Set the grist cache for %s players to %s.");
 		add(SetRungCommand.SUCCESS, "Successfully changed the echeladder of %s players to rung %d with %d%% progress.");

--- a/src/main/java/com/mraof/minestuck/entity/item/GristEntity.java
+++ b/src/main/java/com/mraof/minestuck/entity/item/GristEntity.java
@@ -164,7 +164,7 @@ public class GristEntity extends Entity implements IEntityAdditionalSpawnData
 			Session playerSession = SessionHandler.get(level).getPlayerSession(IdentifierHandler.encode(entityIn));
 			PlayerData data = PlayerSavedData.getData((ServerPlayer) entityIn);
 			
-			long playerGristAmount = data.getGristCache().getGrist(gristType);
+			long playerGristAmount = data.getGristCache().getGristSet().getGrist(gristType);
 			long cacheCapacity = data.getEcheladder().getGristCapacity() - playerGristAmount;
 			
 			long gutterCapacity;

--- a/src/main/java/com/mraof/minestuck/entity/item/GristEntity.java
+++ b/src/main/java/com/mraof/minestuck/entity/item/GristEntity.java
@@ -7,10 +7,7 @@ import com.mraof.minestuck.computer.editmode.ServerEditHandler;
 import com.mraof.minestuck.entity.MSEntityTypes;
 import com.mraof.minestuck.network.GristEntityPacket;
 import com.mraof.minestuck.network.MSPacketHandler;
-import com.mraof.minestuck.player.IdentifierHandler;
-import com.mraof.minestuck.player.PlayerData;
-import com.mraof.minestuck.player.PlayerIdentifier;
-import com.mraof.minestuck.player.PlayerSavedData;
+import com.mraof.minestuck.player.*;
 import com.mraof.minestuck.skaianet.Session;
 import com.mraof.minestuck.skaianet.SessionHandler;
 import net.minecraft.core.BlockPos;
@@ -159,12 +156,11 @@ public class GristEntity extends Entity implements IEntityAdditionalSpawnData
 	
 	public long getPlayerCacheRoom(Player entityIn)
 	{
-		if(entityIn != null && !entityIn.getLevel().isClientSide())
+		if(entityIn instanceof ServerPlayer player)
 		{
 			Session playerSession = SessionHandler.get(level).getPlayerSession(IdentifierHandler.encode(entityIn));
-			PlayerData data = PlayerSavedData.getData((ServerPlayer) entityIn);
 			
-			long cacheCapacity = data.getGristCache().getRemainingCapacity(gristType);
+			long cacheCapacity = GristCache.get(player).getRemainingCapacity(gristType);
 			
 			long gutterCapacity;
 			if(playerSession != null)
@@ -329,8 +325,7 @@ public class GristEntity extends Entity implements IEntityAdditionalSpawnData
 		if(sound)
 			this.playSound(SoundEvents.ITEM_PICKUP, 0.1F, 0.5F * ((this.random.nextFloat() - this.random.nextFloat()) * 0.7F + 1.8F));
 		GristSet set = new GristSet(gristType, gristValue);
-		PlayerSavedData.getData(identifier, level).getGristCache()
-				.addWithGutter(set, GristHelper.EnumSource.CLIENT);
+		GristCache.get(level, identifier).addWithGutter(set, GristHelper.EnumSource.CLIENT);
 		this.discard();
 	}
 	

--- a/src/main/java/com/mraof/minestuck/entity/item/GristEntity.java
+++ b/src/main/java/com/mraof/minestuck/entity/item/GristEntity.java
@@ -328,7 +328,9 @@ public class GristEntity extends Entity implements IEntityAdditionalSpawnData
 			throw new IllegalStateException("Grist entities shouldn't be consumed client-side.");
 		if(sound)
 			this.playSound(SoundEvents.ITEM_PICKUP, 0.1F, 0.5F * ((this.random.nextFloat() - this.random.nextFloat()) * 0.7F + 1.8F));
-		GristHelper.increaseAndNotify(level, identifier, new GristSet(gristType, gristValue), GristHelper.EnumSource.CLIENT);
+		GristSet set = new GristSet(gristType, gristValue);
+		PlayerSavedData.getData(identifier, level).getGristCache()
+				.addWithGutter(set, GristHelper.EnumSource.CLIENT);
 		this.discard();
 	}
 	

--- a/src/main/java/com/mraof/minestuck/entity/item/GristEntity.java
+++ b/src/main/java/com/mraof/minestuck/entity/item/GristEntity.java
@@ -164,8 +164,7 @@ public class GristEntity extends Entity implements IEntityAdditionalSpawnData
 			Session playerSession = SessionHandler.get(level).getPlayerSession(IdentifierHandler.encode(entityIn));
 			PlayerData data = PlayerSavedData.getData((ServerPlayer) entityIn);
 			
-			long playerGristAmount = data.getGristCache().getGristSet().getGrist(gristType);
-			long cacheCapacity = data.getEcheladder().getGristCapacity() - playerGristAmount;
+			long cacheCapacity = data.getGristCache().getRemainingCapacity(gristType);
 			
 			long gutterCapacity;
 			if(playerSession != null)

--- a/src/main/java/com/mraof/minestuck/network/GristToastPacket.java
+++ b/src/main/java/com/mraof/minestuck/network/GristToastPacket.java
@@ -10,15 +10,13 @@ public class GristToastPacket implements PlayToClientPacket
 {
 	private final GristSet gristValue;
 	private final GristHelper.EnumSource source;
-	private final boolean increase;
 	private final long cacheLimit;
 	private final boolean isCacheOwner;
 	
-	public GristToastPacket(GristSet gristValue, GristHelper.EnumSource source, boolean increase, long cacheLimit, boolean isCacheOwner)
+	public GristToastPacket(GristSet gristValue, GristHelper.EnumSource source, long cacheLimit, boolean isCacheOwner)
 	{
 		this.gristValue = gristValue;
 		this.source = source;
-		this.increase = increase;
 		this.cacheLimit = cacheLimit;
 		this.isCacheOwner = isCacheOwner;
 	}
@@ -28,7 +26,6 @@ public class GristToastPacket implements PlayToClientPacket
 	{
 		gristValue.write(buffer);
 		buffer.writeEnum(source);
-		buffer.writeBoolean(increase);
 		buffer.writeLong(cacheLimit);
 		buffer.writeBoolean(isCacheOwner);
 	}
@@ -37,10 +34,9 @@ public class GristToastPacket implements PlayToClientPacket
 	{
 		GristSet gristValue = GristSet.read(buffer);
 		GristHelper.EnumSource source = buffer.readEnum(GristHelper.EnumSource.class);
-		boolean increase = buffer.readBoolean();
 		long cacheLimit = buffer.readLong();
 		boolean isCacheOwner = buffer.readBoolean();
-		return new GristToastPacket(gristValue, source, increase, cacheLimit, isCacheOwner);
+		return new GristToastPacket(gristValue, source, cacheLimit, isCacheOwner);
 	}
 	
 	@Override
@@ -48,8 +44,7 @@ public class GristToastPacket implements PlayToClientPacket
 	{
 		GristSet gristValue = this.gristValue;
 		GristHelper.EnumSource source = this.source;
-		boolean increase = this.increase;
 		GristSet gristCache = ClientPlayerData.getGristCache(this.isCacheOwner);
-		GristToast.sendGristMessage(gristValue, source, increase, this.cacheLimit, gristCache);
+		GristToast.sendGristMessage(gristValue, source, this.cacheLimit, gristCache);
 	}
 }

--- a/src/main/java/com/mraof/minestuck/network/GristToastPacket.java
+++ b/src/main/java/com/mraof/minestuck/network/GristToastPacket.java
@@ -6,7 +6,6 @@ import com.mraof.minestuck.alchemy.GristSet;
 import com.mraof.minestuck.client.gui.toasts.GristToast;
 import com.mraof.minestuck.computer.editmode.EditData;
 import com.mraof.minestuck.computer.editmode.ServerEditHandler;
-import com.mraof.minestuck.player.ClientPlayerData;
 import com.mraof.minestuck.player.PlayerIdentifier;
 import com.mraof.minestuck.player.PlayerSavedData;
 import com.mraof.minestuck.skaianet.SburbConnection;
@@ -14,20 +13,9 @@ import com.mraof.minestuck.skaianet.SkaianetHandler;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.MinecraftServer;
 
-public class GristToastPacket implements PlayToClientPacket
+public record GristToastPacket(GristSet gristValue, GristHelper.EnumSource source, long cacheLimit,
+							   boolean isCacheOwner) implements PlayToClientPacket
 {
-	private final GristSet gristValue;
-	private final GristHelper.EnumSource source;
-	private final long cacheLimit;
-	private final boolean isCacheOwner;
-	
-	public GristToastPacket(GristSet gristValue, GristHelper.EnumSource source, long cacheLimit, boolean isCacheOwner)
-	{
-		this.gristValue = gristValue;
-		this.source = source;
-		this.cacheLimit = cacheLimit;
-		this.isCacheOwner = isCacheOwner;
-	}
 	
 	/**
 	 * Sends a request to make a client-side Toast Notification for incoming/outgoing grist, if enabled in the config.
@@ -46,7 +34,7 @@ public class GristToastPacket implements PlayToClientPacket
 			if(player.getPlayer(server) != null)
 				MSPacketHandler.sendToPlayer(new GristToastPacket(set, source, cacheLimit, true), player.getPlayer(server));
 			
-			if (source == GristHelper.EnumSource.SERVER)
+			if(source == GristHelper.EnumSource.SERVER)
 			{
 				SburbConnection sc = SkaianetHandler.get(server).getActiveConnection(player);
 				if(sc == null)
@@ -58,7 +46,7 @@ public class GristToastPacket implements PlayToClientPacket
 				
 				if(!player.appliesTo(ed.getEditor()))
 					MSPacketHandler.sendToPlayer(new GristToastPacket(set, source, cacheLimit, false), ed.getEditor());
-
+				
 			}
 		}
 	}
@@ -84,9 +72,6 @@ public class GristToastPacket implements PlayToClientPacket
 	@Override
 	public void execute()
 	{
-		GristSet gristValue = this.gristValue;
-		GristHelper.EnumSource source = this.source;
-		GristSet gristCache = ClientPlayerData.getGristCache(this.isCacheOwner);
-		GristToast.sendGristMessage(gristValue, source, this.cacheLimit, gristCache);
+		GristToast.handlePacket(this);
 	}
 }

--- a/src/main/java/com/mraof/minestuck/player/GristCache.java
+++ b/src/main/java/com/mraof/minestuck/player/GristCache.java
@@ -3,6 +3,7 @@ package com.mraof.minestuck.player;
 import com.mraof.minestuck.alchemy.*;
 import com.mraof.minestuck.computer.editmode.EditData;
 import com.mraof.minestuck.computer.editmode.ServerEditHandler;
+import com.mraof.minestuck.network.GristToastPacket;
 import com.mraof.minestuck.network.MSPacketHandler;
 import com.mraof.minestuck.network.data.GristCachePacket;
 import com.mraof.minestuck.skaianet.SburbConnection;
@@ -15,6 +16,7 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.Mth;
 
+import javax.annotation.Nullable;
 import java.util.Objects;
 
 public final class GristCache
@@ -69,7 +71,12 @@ public final class GristCache
 		return GristHelper.canAfford(this.gristSet, cost);
 	}
 	
-	public void addWithGutter(GristSet set)
+	public void takeWithGutter(GristSet set, @Nullable GristHelper.EnumSource source)
+	{
+		addWithGutter(set.copy().scale(-1), source);
+	}
+	
+	public void addWithGutter(GristSet set, @Nullable GristHelper.EnumSource source)
 	{
 		GristSet overflowedGrist = this.addWithinCapacity(set);
 		
@@ -86,6 +93,9 @@ public final class GristCache
 						entity -> entity.setDeltaMovement(entity.getDeltaMovement().multiply(1.5, 0.5, 1.5)), 90, gusherCount);
 			}
 		}
+		
+		if(source != null)
+			GristToastPacket.notify(mcServer, data.identifier, set, source);
 	}
 	
 	public GristSet addWithinCapacity(GristSet set)

--- a/src/main/java/com/mraof/minestuck/player/GristCache.java
+++ b/src/main/java/com/mraof/minestuck/player/GristCache.java
@@ -1,0 +1,76 @@
+package com.mraof.minestuck.player;
+
+import com.mraof.minestuck.alchemy.GristSet;
+import com.mraof.minestuck.alchemy.GristTypes;
+import com.mraof.minestuck.alchemy.ImmutableGristSet;
+import com.mraof.minestuck.alchemy.NonNegativeGristSet;
+import com.mraof.minestuck.computer.editmode.EditData;
+import com.mraof.minestuck.computer.editmode.ServerEditHandler;
+import com.mraof.minestuck.network.MSPacketHandler;
+import com.mraof.minestuck.network.data.GristCachePacket;
+import com.mraof.minestuck.skaianet.SburbConnection;
+import com.mraof.minestuck.skaianet.SkaianetHandler;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerPlayer;
+
+public final class GristCache
+{
+	private final PlayerData data;
+	private final MinecraftServer mcServer;
+	private ImmutableGristSet gristSet;
+	
+	GristCache(PlayerData data, MinecraftServer mcServer)
+	{
+		this.data = data;
+		this.mcServer = mcServer;
+		this.gristSet = new ImmutableGristSet(GristTypes.BUILD, 20);
+	}
+	
+	void read(CompoundTag nbt)
+	{
+		gristSet = NonNegativeGristSet.read(nbt.getList("grist_cache", Tag.TAG_COMPOUND)).asImmutable();
+	}
+	
+	void write(CompoundTag nbt)
+	{
+		nbt.put("grist_cache", gristSet.write(new ListTag()));
+	}
+	
+	public ImmutableGristSet getGristSet()
+	{
+		return this.gristSet;
+	}
+	
+	public void setGristSet(NonNegativeGristSet cache)
+	{
+		gristSet = cache.asImmutable();
+		data.markDirty();
+		data.gristCache.sendPacket(data.getPlayer());
+	}
+	
+	void sendPacket(ServerPlayer player)
+	{
+		GristSet gristSet = this.getGristSet();
+		
+		//Send to the player
+		if(player != null)
+		{
+			GristCachePacket packet = new GristCachePacket(gristSet, false);
+			MSPacketHandler.sendToPlayer(packet, player);
+		}
+		
+		//Also send to the editing player, if there is any
+		SburbConnection c = SkaianetHandler.get(mcServer).getActiveConnection(data.identifier);
+		if(c != null)
+		{
+			EditData data = ServerEditHandler.getData(mcServer, c);
+			if(data != null)
+			{
+				data.sendGristCacheToEditor();
+			}
+		}
+	}
+}

--- a/src/main/java/com/mraof/minestuck/player/GristCache.java
+++ b/src/main/java/com/mraof/minestuck/player/GristCache.java
@@ -15,6 +15,7 @@ import net.minecraft.nbt.Tag;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.Mth;
+import net.minecraft.world.level.Level;
 
 import javax.annotation.Nullable;
 import java.util.Objects;
@@ -30,6 +31,21 @@ public final class GristCache
 		this.data = data;
 		this.mcServer = mcServer;
 		this.gristSet = new ImmutableGristSet(GristTypes.BUILD, 20);
+	}
+	
+	public static GristCache get(ServerPlayer player)
+	{
+		return PlayerSavedData.getData(player).getGristCache();
+	}
+	
+	public static GristCache get(Level level, PlayerIdentifier player)
+	{
+		return PlayerSavedData.getData(player, level).getGristCache();
+	}
+	
+	public static GristCache get(MinecraftServer mcServer, PlayerIdentifier player)
+	{
+		return PlayerSavedData.getData(player, mcServer).getGristCache();
 	}
 	
 	public NonNegativeGristSet getCapacitySet()

--- a/src/main/java/com/mraof/minestuck/player/GristCache.java
+++ b/src/main/java/com/mraof/minestuck/player/GristCache.java
@@ -113,7 +113,7 @@ public final class GristCache
 	
 	public void addWithGutter(GristSet set, @Nullable GristHelper.EnumSource source)
 	{
-		GristSet overflowedGrist = this.addWithinCapacity(set);
+		GristSet overflowedGrist = this.addWithinCapacity(set, source);
 		
 		if(!overflowedGrist.isEmpty())
 		{
@@ -128,12 +128,9 @@ public final class GristCache
 						entity -> entity.setDeltaMovement(entity.getDeltaMovement().multiply(1.5, 0.5, 1.5)), 90, gusherCount);
 			}
 		}
-		
-		if(source != null)
-			GristToastPacket.notify(mcServer, data.identifier, set, source);
 	}
 	
-	public GristSet addWithinCapacity(GristSet set)
+	public GristSet addWithinCapacity(GristSet set, @Nullable GristHelper.EnumSource source)
 	{
 		Objects.requireNonNull(set);
 		
@@ -142,6 +139,9 @@ public final class GristCache
 		GristSet excessGrist = addWithinCapacity(newCache, set, data.getEcheladder().getGristCapacity());
 		
 		this.set(newCache);
+		if(source != null)
+			GristToastPacket.notify(mcServer, data.identifier, set, source);
+		
 		return excessGrist;
 	}
 	

--- a/src/main/java/com/mraof/minestuck/player/GristCache.java
+++ b/src/main/java/com/mraof/minestuck/player/GristCache.java
@@ -138,9 +138,12 @@ public final class GristCache
 		
 		GristSet excessGrist = addWithinCapacity(newCache, set, data.getEcheladder().getGristCapacity());
 		
-		this.set(newCache);
-		if(source != null)
-			GristToastPacket.notify(mcServer, data.identifier, set, source);
+		if(!excessGrist.equalContent(set))
+		{
+			this.set(newCache);
+			if(source != null)
+				GristToastPacket.notify(mcServer, data.identifier, set, source);
+		}
 		
 		return excessGrist;
 	}

--- a/src/main/java/com/mraof/minestuck/player/GristCache.java
+++ b/src/main/java/com/mraof/minestuck/player/GristCache.java
@@ -83,13 +83,32 @@ public final class GristCache
 	
 	public boolean canAfford(GristSet cost)
 	{
-		//TODO must also check the capacity for negative costs
-		return GristHelper.canAfford(this.gristSet, cost);
+		return canAdd(cost.copy().scale(-1));
 	}
 	
-	public void takeWithGutter(GristSet set, @Nullable GristHelper.EnumSource source)
+	public boolean canAdd(GristSet addition)
 	{
-		addWithGutter(set.copy().scale(-1), source);
+		return addWithinCapacity(this.gristSet.copy(), addition, data.getEcheladder().getGristCapacity()).isEmpty();
+	}
+	
+	public boolean tryTake(GristSet cost, @Nullable GristHelper.EnumSource source)
+	{
+		GristSet change = cost.copy().scale(-1);
+		
+		NonNegativeGristSet newCache = new NonNegativeGristSet(this.getGristSet());
+		
+		GristSet excessGrist = addWithinCapacity(newCache, change, data.getEcheladder().getGristCapacity());
+		
+		if(excessGrist.isEmpty())
+		{
+			this.set(newCache);
+			
+			if(source != null)
+				GristToastPacket.notify(mcServer, data.identifier, change, source);
+			
+			return true;
+		} else
+			return false;
 	}
 	
 	public void addWithGutter(GristSet set, @Nullable GristHelper.EnumSource source)


### PR DESCRIPTION
Continues with some cleanup and fixing problems.
It introduces the `GristCache` class, which does a lot of what `GristHelper` used to do. With it, the upper and lower bounds of the grist cache are now more robustly enforced, so that it doesn't lead to any weird behavior if the cache would end up out-of-bounds one way or another.
Ways that involve taking grist from the cache now uses a different function that does not involve the grist gutter at all. I've also made the `/grist add` command strictly not pass grist to the gutter, instead discarding grist changes beyond the cache capacity, and giving a feedback message accordingly.

The grist toasts have been cleaned up a bit too, removing some text from the old version of the toast, ensuring a correct cache value when updating a toast, and improving code quality for a portion of the `GristToast` class.
The mini alchemiter should now produce grist toasts as well.